### PR TITLE
Add long_description_content_type

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
     author_email="dave@raspberrypi.org",
     description="Python module to control the Raspberry Pi Sense HAT, originally used in the Astro Pi mission",
     long_description=read('README.md'),
+    long_description_content_type="text/markdown",
     license="BSD",
     keywords=[
         "sense hat",


### PR DESCRIPTION
Set it to markdown so that the README passes `twine check` and unblocks `twine uplload`