### PR TITLE
Added function to return only RGB values from the colour sensor

### DIFF
--- a/sense_hat/colour.py
+++ b/sense_hat/colour.py
@@ -1,35 +1,3 @@
-Skip to content
-Search or jump to…
-Pull requests
-Issues
-Marketplace
-Explore
- 
-@snake48 
-astro-pi
-/
-python-sense-hat
-Public
-Code
-Issues
-25
-Pull requests
-9
-Actions
-Projects
-Wiki
-Security
-Insights
-python-sense-hat/sense_hat/colour.py /
-@G3zz
-G3zz Small improvements to lib
-…
-Latest commit 9a67533 on 1 Jun
- History
- 2 contributors
-@boukeas@G3zz
-358 lines (301 sloc)  11.6 KB
-
 """
 Python library for the TCS34725 Color Sensor
 Documentation (including datasheet): https://ams.com/tcs34725#tab/documents
@@ -390,17 +358,3 @@ class ColourSensor:
     green = property(lambda self: self.green_raw // self._scaling )
     blue = property(lambda self: self.blue_raw // self._scaling )
     clear = property(lambda self: self.clear_raw // self._scaling )
-Footer
-© 2022 GitHub, Inc.
-Footer navigation
-Terms
-Privacy
-Security
-Status
-Docs
-Contact GitHub
-Pricing
-API
-Training
-Blog
-About

--- a/sense_hat/colour.py
+++ b/sense_hat/colour.py
@@ -1,3 +1,35 @@
+Skip to content
+Search or jump to…
+Pull requests
+Issues
+Marketplace
+Explore
+ 
+@snake48 
+astro-pi
+/
+python-sense-hat
+Public
+Code
+Issues
+25
+Pull requests
+9
+Actions
+Projects
+Wiki
+Security
+Insights
+python-sense-hat/sense_hat/colour.py /
+@G3zz
+G3zz Small improvements to lib
+…
+Latest commit 9a67533 on 1 Jun
+ History
+ 2 contributors
+@boukeas@G3zz
+358 lines (301 sloc)  11.6 KB
+
 """
 Python library for the TCS34725 Color Sensor
 Documentation (including datasheet): https://ams.com/tcs34725#tab/documents
@@ -15,7 +47,6 @@ class HardwareInterface:
     actual hardware. Using this intermediate layer of abstraction, a
     `ColourSensor` object interacts with the hardware without being
     aware of how this interaction is implemented.
-
     Different subclasses of the `HardwareInterface` class can provide
     access to the hardware through e.g. I2C, `libiio` and its system
     files or even a hardware emulator.
@@ -131,7 +162,6 @@ class I2C(HardwareInterface):
     """
     An implementation of the `HardwareInterface` for the TCS34725 sensor
     that uses I2C to control the sensor and retrieve measurements.
-
     Use the datasheet as a reference: https://ams.com/tcs34725#tab/documents
     """
 
@@ -351,8 +381,26 @@ class ColourSensor:
     def colour(self):
         return tuple(reading // self._scaling for reading in self.colour_raw)
 
+    @property
+    def rgb(self):
+        return tuple(reading // self._scaling for reading in self.colour_raw)[0:3]
+
     color = colour
     red = property(lambda self: self.red_raw // self._scaling )
     green = property(lambda self: self.green_raw // self._scaling )
     blue = property(lambda self: self.blue_raw // self._scaling )
     clear = property(lambda self: self.clear_raw // self._scaling )
+Footer
+© 2022 GitHub, Inc.
+Footer navigation
+Terms
+Privacy
+Security
+Status
+Docs
+Contact GitHub
+Pricing
+API
+Training
+Blog
+About


### PR DESCRIPTION
The addition if this function makes it easier to directly pass the RGB values from the colour sensor into a function that takes an RGB values as an argument.

e.g
`sh.clear(sh.colour.rgb)`