### PR TITLE
TCS34725 and TCS3400 support

### DIFF
--- a/sense_hat/exceptions.py
+++ b/sense_hat/exceptions.py
@@ -11,7 +11,7 @@ class SenseHatException(Exception):
 
 
 class ColourSensorInitialisationError(SenseHatException):
-    fmt = "Failed to initialise TCS34725 colour sensor. {explanation}"
+    fmt = "Failed to initialise colour sensor. {explanation}"
 
 
 class InvalidGainError(SenseHatException):

--- a/sense_hat/sense_hat.py
+++ b/sense_hat/sense_hat.py
@@ -208,10 +208,8 @@ class SenseHat(object):
     def colour(self):
         try:
             return self._colour
-        except AttributeError as e:
-            raise ColourSensorInitialisationError(
-                explanation="This Sense HAT" +
-                            " does not have a color sensor") from e
+        except AttributeError:
+            print('This Sense Hat does not have a colour sensor')
 
     color = colour
 


### PR DESCRIPTION
Detects the used sensor. so the same code supports both. TCS3400 is used for the Sense Hat V2 while the (discontinued) TCS34725 is used on the AstroPi sense hat for the ISS.

Also included a bug fix for the computation of the red_raw, green_raw, blue_raw and clear_raw values. The original code ony fetched the LSB, not the complete 16-bit value.

See also issue #126